### PR TITLE
fix: correct directory creation and path resolution

### DIFF
--- a/imagesave.php
+++ b/imagesave.php
@@ -1,11 +1,11 @@
 <?php
 	// requires php8
-	define('UPLOAD_DIR', './pictures/');
+	define('UPLOAD_DIR', 'pictures');
 	$dir = time();
   // Check if the directory already exists
-  if (!is_dir(UPLOAD_DIR . $dir)) {
-    if (!mkdir(UPLOAD_DIR . $dir, 0755, true)) {
-      die('Failed to create directories: ' . UPLOAD_DIR . $dir);
+  if (!is_dir(UPLOAD_DIR)) {
+    if (!mkdir(UPLOAD_DIR, 0755, true)) {
+      die('Failed to create directories: ' . $dir);
     }
   }
 	$post = $_POST['img'] ?? '';


### PR DESCRIPTION
This pull request includes a modification to the `imagesave.php` file to simplify the directory creation logic and correct the `UPLOAD_DIR` path. The most important changes include updating the `UPLOAD_DIR` definition and adjusting the directory creation checks.

Changes to directory handling:

* [`imagesave.php`](diffhunk://#diff-4d736cb6bcb610e343bac0560cce014f1ee3caf25326ab878a7c4d2931702d06L3-R8): Updated the `UPLOAD_DIR` definition to remove the trailing slash and corrected the directory creation logic to check if the `UPLOAD_DIR` exists instead of `UPLOAD_DIR . $dir`.