### PR TITLE
fix: correct image saving logic

### DIFF
--- a/imagesave.php
+++ b/imagesave.php
@@ -4,14 +4,14 @@
 	$dir = time();
   // Check if the directory already exists
   if (!is_dir(UPLOAD_DIR)) {
-    if (!mkdir(UPLOAD_DIR, 0755, true)) {
-      die('Failed to create directories: ' . $dir);
+    if (!mkdir(UPLOAD_DIR . $dir, 0755, true)) {
+      die('Failed to create directories: ' . UPLOAD_DIR . $dir);
     }
   }
 	$post = $_POST['img'] ?? '';
 	$images = explode('data:image/png;base64,', $post);
 	$snapstr = UPLOAD_DIR . $dir . '/snapstr.png';
-  if(!copy(UPLOAD_DIR . '/snapstr.png', $snapstr)) {
+  if(!copy(UPLOAD_DIR . $dir . '/snapstr.png', $snapstr)) {
     print "IMAGE DUPLICATE FAILED";
     return FALSE;
   }


### PR DESCRIPTION
This pull request includes a change to the `imagesave.php` file to fix the directory creation and image copying logic.

Directory creation and image copying logic improvements:

* Changed the `mkdir` function to include the timestamp directory, ensuring unique directories are created for each upload.
* Updated the `die` message to include the full directory path for better debugging.
* Modified the `copy` function to use the correct path, including the timestamp directory, to prevent image duplication errors.