### PR TITLE
fix(upload): correct file upload path

### DIFF
--- a/imagesave.php
+++ b/imagesave.php
@@ -10,7 +10,7 @@
   }
 	$post = $_POST['img'] ?? '';
 	$images = explode('data:image/png;base64,', $post);
-	$snapstr = UPLOAD_DIR . $dir . '/snapstr.png';
+	$snapstr = UPLOAD_DIR . '/snapstr.png';
   if(!copy(UPLOAD_DIR . $dir . '/snapstr.png', $snapstr)) {
     print "IMAGE DUPLICATE FAILED";
     return FALSE;


### PR DESCRIPTION
This pull request includes a small change to the `imagesave.php` file. The change simplifies the path for saving the image by removing the directory variable from the assignment.

* [`imagesave.php`](diffhunk://#diff-4d736cb6bcb610e343bac0560cce014f1ee3caf25326ab878a7c4d2931702d06L13-R13): Simplified the path for saving the image by removing the `$dir` variable from the assignment of `$snapstr`.